### PR TITLE
[ubnt-unifi-switch-poe-on-off.sh] avoid usage temporary file

### DIFF
--- a/ubnt-unifi-switch-poe-on-off.sh
+++ b/ubnt-unifi-switch-poe-on-off.sh
@@ -3,7 +3,6 @@
 # Usage:
 #   $ ubnt-unifi-switch-poe-on-off.sh 192.168.1.20 1
 
-CMD=".cmd.txt"
 USR=ubnt
 PWD=ubnt
 
@@ -12,22 +11,16 @@ LANPORT="$2"
 
 echo "===== Disable PoE port: ${LANPORT} at ${IP} ====="
 
-cat > $CMD << EOF
-(echo "enable" ; echo "configure" ; echo "interface 0/$LANPORT" ; echo "poe opmode shutdown"; echo exit; echo exit; echo exit) | nc localhost 23
-EOF
+CMD='(echo "enable" ; echo "configure" ; echo "interface 0/'$LANPORT'" ; echo "poe opmode shutdown"; echo exit; echo exit; echo exit) | nc localhost 23'
 
-sshpass -p $PWD ssh -q $USR@$IP $(cat $CMD)
+sshpass -p $PWD ssh -q $USR@$IP $(echo $CMD)
 
 # Sleep for 500ms
 sleep 0.5
 
 echo "===== Enable  PoE port: ${LANPORT} at ${IP} ====="
 
-cat > $CMD << EOF
-(echo "enable" ; echo "configure" ; echo "interface 0/$LANPORT" ; echo "poe opmode auto"; echo exit; echo exit; echo exit) | nc localhost 23
-EOF
+CMD='(echo "enable" ; echo "configure" ; echo "interface 0/'$LANPORT'" ; echo "poe opmode auto"; echo exit; echo exit; echo exit) | nc localhost 23'
 
-sshpass -p $PWD ssh -q $USR@$IP $(cat $CMD)
-
-rm $CMD
+sshpass -p $PWD ssh -q $USR@$IP $(echo $CMD)
 


### PR DESCRIPTION
It is possible to issue command directly without temporary file.