### PR TITLE
fix(scp): use `-O` option

### DIFF
--- a/scp.sh
+++ b/scp.sh
@@ -13,6 +13,6 @@ DEVICE_IP="$1"
 SSH_OPTION_IGNORE_CHECK="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
 
 for passwd in ${SSH_PASS:-ubnt}; do
-	sshpass -p ${passwd} scp -P ${SSH_PORT:-22} $SSH_OPTION_IGNORE_CHECK -r "${@:2}" ${SSH_USER:-ubnt}@$DEVICE_IP:/tmp/
+	sshpass -p ${passwd} scp -O -P ${SSH_PORT:-22} $SSH_OPTION_IGNORE_CHECK -r "${@:2}" ${SSH_USER:-ubnt}@$DEVICE_IP:/tmp/
 	[ $? -eq 0 ] && { echo "done"; exit 0; } || echo "try next..."
 done

--- a/ssh.sh
+++ b/ssh.sh
@@ -25,7 +25,7 @@ until nc -vzw 2 $DEVICE_IP 22 2>/dev/null; do sleep 0.3; done
 BASHRC_BB=".bashrc_bb_u"
 SSH_OPTION_IGNORE_CHECK="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
 for passwd in ${SSH_PASS:-ubnt}; do
-	sshpass -p ${passwd} scp $SSH_OPTION_IGNORE_CHECK `dirname $0`/$BASHRC_BB ${SSH_USER:-ubnt}@$DEVICE_IP:/tmp/
+	sshpass -p ${passwd} scp -O $SSH_OPTION_IGNORE_CHECK `dirname $0`/$BASHRC_BB ${SSH_USER:-ubnt}@$DEVICE_IP:/tmp/
 	[ $? -eq 0 ] && break || echo "try next..."
 done
 

--- a/upload_bin
+++ b/upload_bin
@@ -26,7 +26,7 @@ METHOD=2
 
 case $METHOD in
 	1)
-		sshpass -p ${SSH_PASS:-ubnt} scp $SSH_OPTION_IGNORE_CHECK "$FW_BIN" ${SSH_USER:-ubnt}@"$DEVICE_IP":/tmp/fwupdate.bin
+		sshpass -p ${SSH_PASS:-ubnt} scp -O $SSH_OPTION_IGNORE_CHECK "$FW_BIN" ${SSH_USER:-ubnt}@"$DEVICE_IP":/tmp/fwupdate.bin
 		sshpass -p ${SSH_PASS:-ubnt} ssh $SSH_OPTION_IGNORE_CHECK ${SSH_USER:-ubnt}@"$DEVICE_IP" /usr/bin/fwupdate -m || echo "FW upload fail!"
 		;;
 	2)
@@ -38,8 +38,9 @@ case $METHOD in
 		for passwd in ${SSH_PASS:-ubnt}; do
 			#sshpass -p ${passwd} ssh-copy-id $SSH_OPTION_IGNORE_CHECK -i "$KEY".pub ${SSH_USER:-ubnt}@"$DEVICE_IP" >/dev/null 2>&1
 			sshpass -p ${passwd} ssh ${SSH_USER:-ubnt}@"$DEVICE_IP" "tee -a /etc/dropbear/authorized_keys" < "$KEY".pub >/dev/null 2>&1
+
 			[ $? -eq 0 ] || { echo "try next..."; continue; }
-			scp $SSH_OPTION_IGNORE_CHECK -i "$KEY" "$FW_BIN" ${SSH_USER:-ubnt}@"$DEVICE_IP":/tmp/fwupdate.bin
+			scp -O $SSH_OPTION_IGNORE_CHECK -i "$KEY" "$FW_BIN" ${SSH_USER:-ubnt}@"$DEVICE_IP":/tmp/fwupdate.bin
 			[ $? -eq 0 ] && { ssh -i "$KEY" ${SSH_USER:-ubnt}@"$DEVICE_IP" /usr/bin/fwupdate -m; exit $?; } || echo "FW upload fail!"
 		done
 		;;


### PR DESCRIPTION
## Description

Make macOS (Darwin) happy~

```
 -O      Use the original SCP protocol for file transfers instead of the SFTP protocol.
```

Closes JIRA-XXX

## Type of change

Please delete options that are not relevant.

- [X] Improvement (existing functionality improvement)

## Before this PR

macOS is not happy to cooperate with UniFi-Protect Camera `scp`

## After this PR

All good!

## How Has This Been Tested?

- [X] tested on Kent-Studio MBP

## Related PR

TBD

